### PR TITLE
update packages to be useable with current Strapi

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   },
   "dependencies": {
     "@ckeditor/ckeditor5-react": "^4.0.0",
-    "@strapi/design-system": "^0.0.1-alpha.70",
-    "@strapi/helper-plugin": "^4.1.5",
-    "ckeditor5-build-strapi-wysiwyg": "^2.1.1",
+    "@strapi/design-system": "^1.1.0",
+    "@strapi/helper-plugin": "^4.2.0-beta.2",
+    "ckeditor5-build-strapi-wysiwyg": "https://github.com/JournalOfTrialAndError/ckeditor5-build-strapi-wysiwyg",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "^4.0.0",
     "@strapi/design-system": "^1.1.0",
     "@strapi/helper-plugin": "^4.2.0-beta.2",
-    "ckeditor5-build-strapi-wysiwyg": "https://github.com/JournalOfTrialAndError/ckeditor5-build-strapi-wysiwyg",
+    "ckeditor5-build-strapi-wysiwyg": "^2.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },


### PR DESCRIPTION
This fixes #47 by using strapi's modern design system. Not sure if it breaks anything for older versions.